### PR TITLE
backwards compatibility with PHP 5.3.x

### DIFF
--- a/module/dispatcher/dispatcher.php
+++ b/module/dispatcher/dispatcher.php
@@ -5,12 +5,12 @@
  use t0t1\mysfw\frame;
 
  class dispatcher extends frame\dna implements frame\contract\dna {
-  protected $_defaults = [
+  protected $_defaults = array(
    'dispatcher:controller'        => 'generic_controller',
    'dispatcher:controller_suffix' => '_controller',
    'dispatcher:parameter'         => 'controller',
    'dispatcher:default'           => 'index',
-   ];
+   );
 
   protected function _get_ready() {
    $this->report_debug("Dispatcher is ready");

--- a/module/file_reporter/file_reporter.php
+++ b/module/file_reporter/file_reporter.php
@@ -8,11 +8,11 @@
   private $_fd;
   private $_level_ceil = 3;
 
-  protected $_defaults = [
+  protected $_defaults = array(
    'root' => '',
    'report_dir' => '../reports/',
    'report_file_name' => 'default.report'
-    ];
+    );
 
   protected function _get_ready() {
    $report = $this->inform('root').$this->inform('report_dir').$this->inform('report_file_name');

--- a/module/mysql_data_storage/mysql_data_storage.php
+++ b/module/mysql_data_storage/mysql_data_storage.php
@@ -13,13 +13,13 @@
 
  class mysql_data_storage extends frame\dna implements frame\contract\data_storage, frame\contract\dna { 
   protected $_statement_prefix = 'sql_statements';
-  protected $_defaults = [
+  protected $_defaults = array(
    'mysql:host' => 'localhost',
    'mysql:port' => 3306,
    'mysql:user' => 'mysfw',
    'mysql:pass' => 'mysfw',
    'mysql:db'   => 'mysfw',
-   ];
+   );
 
 
   /** XXX TEMP **/
@@ -42,7 +42,7 @@
   protected function _query_and_fetch($sql, $c) {
    $r = $this->_query($c, $sql);
 
-   $res = [];
+   $res = array();
    while($row = $r->fetch_object()) {
     $res[] = $row;
    }

--- a/module/operator/operator.php
+++ b/module/operator/operator.php
@@ -23,18 +23,18 @@
   private $_data_storage;
   private $_uid_injection = null;
 
-  protected $_defaults = [
-   'operators:generic_definitions' => ['_id' => null],  // XXX draft generic definition
-   'operators:custom_definitions'  => [                 // XXX draft operator specific definitions
-    'user' => ['id' => null]
-    ]
-   ];
+  protected $_defaults = array(
+   'operators:generic_definitions' => array('_id' => null),  // XXX draft generic definition
+   'operators:custom_definitions'  => array(                 // XXX draft operator specific definitions
+    'user' => array('id' => null)
+    )
+   );
 
   protected $_mns = '\t0t1\mysfw\module\operator'; //XXX used by dna:except()
-  protected $_exceptions = [   // XXX TEMP exceptions definition
+  protected $_exceptions = array(   // XXX TEMP exceptions definition
    'no_entry' => 1,
    'too_many_entries' => 1
-    ];
+    );
 
   protected function _new_identify($defs) {
   }


### PR DESCRIPTION
Using the long syntax for array for backwards compatibility with PHP 5.3.x
