### PR TITLE
resource_iterator

### DIFF
--- a/frame/contract/resource_iterator.php
+++ b/frame/contract/resource_iterator.php
@@ -1,0 +1,7 @@
+<?php
+namespace t0t1\mysfw\frame\contract;
+
+interface resource_iterator{
+    public function wrap($resource,$operator_type);
+    public function count();
+}

--- a/frame/contract/resource_iterator.php
+++ b/frame/contract/resource_iterator.php
@@ -3,5 +3,6 @@ namespace t0t1\mysfw\frame\contract;
 
 interface resource_iterator{
     public function wrap($resource,$operator_type);
-    public function count();
+    public function count($use_limit);
+    public function shift();
 }

--- a/module/mongodb_data_storage/mongodb_data_storage.php
+++ b/module/mongodb_data_storage/mongodb_data_storage.php
@@ -185,9 +185,9 @@
          }
          $this->report_debug(print_r($metacrit, true));
    }
-   $results = iterator_to_array($data, false);
-   $this->report_debug(count($results)." `$type` item(s) retrieved");
-   return $results;
+   $iterator = $this->pop('mongodb_iterator')->wrap($data, $type);
+   $this->report_debug($iterator->count()." `$type` item(s) retrieved");
+   return $iterator;
   }
 
 

--- a/module/mongodb_iterator/mongodb_iterator.php
+++ b/module/mongodb_iterator/mongodb_iterator.php
@@ -1,0 +1,54 @@
+<?php
+namespace t0t1\mysfw\module;
+use t0t1\mysfw\frame;
+
+$this->_learn('frame\contract\resource_iterator');
+$this->_learn('module\resource_iterator\exception\invalid_parameters');
+
+class mongodb_iterator extends frame\dna implements frame\contract\resource_iterator,\Iterator{
+
+    protected $_mns = '\t0t1\mysfw\module\resource_iterator'; //XXX used by dna:except()
+    protected $_exceptions = array(   // XXX TEMP exceptions definition
+        'invalid_parameters' =>     1,
+    );
+
+    private $_resource, $_operator, $_operator_under_laying_type= false;
+
+    public function __toString(){
+        return json_encode(array('class'=>__CLASS__,'operator_type'=>$this->_operator_under_laying_type,'total'=>$this->count(),'returned'=>$this->count(true)));
+    }
+
+    public function wrap($resource,$operator_type){ // __contruct?
+        if( ! $resource instanceof \MongoCursor){
+            $err= sprintf('Result set must be a valid MongoCursor, found %s',get_class($resource));
+            $this->report_error($e);
+            throw $this->except($err, 'invalid_parameters');
+        }
+        $this->_resource=                   $resource;
+        $this->_operator_under_laying_type= $operator_type;
+        $this->_operator=                   $this->pop('operator')->morph($this->_operator_under_laying_type);
+        return $this;
+    }
+
+    public function count($use_limit=false){
+        return $this->_resource->count($use_limit)?:0;
+    }
+
+    public function rewind(){$this->_resource->rewind();}
+    public function next(){$this->_resource->getNext();}
+    public function key(){return $this->_resource->key();}
+    public function valid(){return $this->_resource->valid();}
+
+    public function current(){
+        //XXX if I only could retrieve uid composition from operator, I could check if this key exists and identify the operator
+        //caveat you should always use foreach to get current
+        return $this->_operator->set_values($this->_resource->current());
+    }
+
+    public function shift(){
+        if($this->_resource->hasNext()){
+            $this->next();
+        }
+        return $this->current();
+    }
+}

--- a/module/resource_iterator/exception/invalid_parameters.php
+++ b/module/resource_iterator/exception/invalid_parameters.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace t0t1\mysfw\module\resource_iterator\exception;
+use t0t1\mysfw\frame;
+
+class invalid_parameters extends frame\exception\dna {}


### PR DESCRIPTION
introducing a resource_iterator kind of objects that allow to reduce memory footprint for object/lib that may return iterators instead of storing the whole result set in memory.

This object returns "on the fly" fully populated operators.
Atm only mongodb_data_storage::retrieve has been moded to use it.

Here is a kick batch to test both old and new mongodb_data_storage::retrieve foot print ( this batch could be located under "examples" directory ) : 

```php
<?php
$popper = call_user_func(require __DIR__.'/../init.php', __DIR__);

$popper->register('data_storage', 'mongodb_data_storage');
$popper->indicate('configurator')
    ->define('operators:generic_definitions', array('_id' => null));

// bulk insert
$max= 10000;
for($i=1;$i<=$max;$i++){
    $fixture= $popper->pop('operator')->morph('fixture');
    foreach(array('prop1','prop2','prop3','prop4') as $prop){
        $fixture->set($prop, uniqid($prop,true));
    }
    $fixture->create();
    fwrite(STDOUT, sprintf('inserted %s fixture(s) over %s',$i,$max));
    fwrite(STDOUT, "\n");
}
$ds= $popper->indicate('data_storage');
$fixtures= $ds->retrieve('fixture',array());
$count= method_exists($fixtures,'count')?$fixtures->count():count($fixtures);
fwrite(STDOUT, sprintf('Total row retrieved %s', $count));
fwrite(STDOUT, "\n");
$memory_peak_usage= memory_get_peak_usage(true);
fwrite(STDOUT, sprintf('Total memory used : %s', $memory_peak_usage ? round($memory_peak_usage/pow(1024, ($i = floor(log($memory_peak_usage, 1024)))), 2) .array(" Octets", " Ko", " Mo", " Go", " To", " Po", " Eo", " Zo", " Yo")[$i] : '0 Octets'));
fwrite(STDOUT, "\n");
```

@LaurentGrimaud : could you please review this feature and let me know if there is any corrections needed and if you think that there is a better solution ?



